### PR TITLE
Feature/argument passing/wait  Fix: process_wait 함수 수정

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -18,6 +18,7 @@
 #include "threads/mmu.h"
 #include "threads/vaddr.h"
 #include "intrinsic.h"
+#include "devices/timer.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -242,9 +243,8 @@ process_wait (tid_t child_tid UNUSED) {
 	 /* XXX: 힌트) PintOS는 process_wait(initd)가 호출되면 종료됩니다.
 	 * XXX: process_wait를 구현하기 전에 이 부분에 무한 루프를 추가하는 것을 권장합니다. */
 
-	 while(true){
-
-	 }
+	//  while(true){}
+	timer_sleep(400);
 	return -1;
 }
 


### PR DESCRIPTION
process_wait()함수에서 기존 주석에서는 다음과 같이 무한 루프를 추가하라고 되어 있습니다.

```
/* XXX: Hint) The pintos exit if process_wait(initd), we recommend you
 * XXX:       to add infinite loop here before
 * XXX:       implementing the process_wait. */

/* XXX: 힌트) PintOS는 process_wait(initd)가 호출되면 종료됩니다.
 * XXX: process_wait를 구현하기 전에 이 부분에 무한 루프를 추가하는 것을 권장합니다. */
```

하지만 저희 팀은 해당 위치에 무한 루프를 두는 대신, Project 1의 Alarm Clock에서 구현했던 timer_sleep() 함수를 활용하여 약 4초간 대기하도록 수정하는 방향으로 정했습니다.

불필요한 무한 루프를 피하면서도, process_wait()를 구현하기 전 종료를 방지하는 목적을 충분히 달성한다고 판단하였습니다.