### PR TITLE
Add: file_name을 파싱하고 리스트에 저장하는 부분 구현

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -42,6 +42,10 @@ tid_t
 process_create_initd (const char *file_name) {
 	char *fn_copy;
 	tid_t tid;
+	char *save_ptr;
+
+	char *parse_filename = strtok_r(file_name, " ", &save_ptr);
+	printf(parse_filename);
 
 	/* Make a copy of FILE_NAME.
 	 * Otherwise there's a race between the caller and load(). */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -42,10 +42,6 @@ tid_t
 process_create_initd (const char *file_name) {
 	char *fn_copy;
 	tid_t tid;
-	char *save_ptr;
-
-	char *parse_filename = strtok_r(file_name, " ", &save_ptr);
-	printf(parse_filename);
 
 	/* Make a copy of FILE_NAME.
 	 * Otherwise there's a race between the caller and load(). */
@@ -53,6 +49,16 @@ process_create_initd (const char *file_name) {
 	if (fn_copy == NULL)
 		return TID_ERROR;
 	strlcpy (fn_copy, file_name, PGSIZE);
+
+	/* 프로젝트 2 - 파싱(Parsing)*/
+	char *argv[64]; //8의 배수로 지정했음 
+	int argc = 0;
+	char *token, *save_ptr;
+
+	for (token = strtok_r(fn_copy, " ", &save_ptr); token != NULL;
+    token = strtok_r(NULL, " ", &save_ptr)) {
+    	argv[argc++] = token;
+	}
 
 	/* Create a new thread to execute FILE_NAME. */
 	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);


### PR DESCRIPTION
**process_create_initd 함수** 안에서 **file_name에서 받은 인자를 파싱하는 부분**을 추가합니다.

`strtok_r()`을 이용하여 토큰(파싱된 스트링)들이 `argv[argc]`에 저장이 되도록 구현했습니다. 

구현 방식은 _pintos/threads_의 parse_options 함수를 참고했습니다. 