### PR TITLE
System Call : Halt 함수 추가

### DIFF
--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -44,3 +44,9 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	printf ("system call!\n");
 	thread_exit ();
 }
+
+/* power_off()를 호풀하며 PintOS를 종료시킨다.
+	유저 프로그램에서 OS를 멈출 수 있는 유일한 시스템 콜 이다. */
+void halt (void) {
+	power_off(); 
+}

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -45,7 +45,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	thread_exit ();
 }
 
-/* power_off()를 호풀하며 PintOS를 종료시킨다.
+/* power_off()를 호출하며 PintOS를 종료시킨다.
 	유저 프로그램에서 OS를 멈출 수 있는 유일한 시스템 콜 이다. */
 void halt (void) {
 	power_off(); 


### PR DESCRIPTION
System Call의 **Halt 함수를 추가**했습니다. 

`void halt (void)` 함수는` power_off()`를 호출하며 PintOS를 중지시키는 함수이고, 유저 프로그램에서 OS를 멈출 수 있는 유일한 시스템 콜입니다. 

