### PR TITLE
System Call: check_address 함수 추가

### DIFF
--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -37,6 +37,15 @@ syscall_init (void) {
 			FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
 }
 
+/* 시스템 콜 인자로 전달된 유저 포인터가 가리키고 있는 주소가 유효 한지 확인합니다.
+	커널 주소 영역이거나 유저 페이지 테이블에 매핑 되지 않은 주소 라면 종료(exit(-1)) 시킵니다. */
+void
+check_address (void *addr) {
+	if (is_kernel_vaddr(addr) || pml4_get_page(thread_current()->pml4, addr) == 0) {
+		exit(-1);
+	}
+}
+
 /* The main system call interface */
 void
 syscall_handler (struct intr_frame *f UNUSED) {


### PR DESCRIPTION
유저가 system call을 호출할때, **시스템 콜 인자로 전달된 유저 포인터가 가리키고 있는 주소가 유효한지를 확인**합니다. 

threads/vaddr.h에 있는 `is_kernel_vaddr`(커널 가상 주소인지 확인하는 함수)를 사용하여 커널 주소 영역에 있는지 확인하고, 유저 페이지 매핑 테이블에 이미 매핑 되어 있는지도 확인합니다. 이 둘중에 하나라도 조건을 만족하지 않는다면` exit()`을 호출합니다.
