### PR TITLE
System Call: exit 구현 및 write 부분 구현

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,7 +11,8 @@
             ],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",
-            "intelliSenseMode": "linux-gcc-x64"
+            "intelliSenseMode": "linux-gcc-x64",
+            "compilerArgs": ["-nostdinc"]
         }
     ],
     "version": 4

--- a/pintos/userprog/.test_config
+++ b/pintos/userprog/.test_config
@@ -1,110 +1,120 @@
-# .test_config
-# 포맷: 테스트이름: 실행인자 ('--' 포함) : 경로
+# .test_config format:
+# test_name | pre_args | post_args | prog_args | test_path
+#
+# Fields:
+#   test_name : 테스트 식별용 이름
+#   pre_args  : 'pintos' 호출 시 -- 이전 옵션들
+#   post_args : 'pintos' 호출 시 -- 이후, run 이전 옵션들
+#   prog_args : 작은따옴표로 묶인 테스트 실행 인자 전체
+#   test_path : 테스트 바이너리 경로 (호스트 파일 시스템 내)
 
-[User Program]
-args-none:               -q -f -- : tests/userprog
-args-single:             -q -f -- onearg : tests/userprog
-args-multiple:           -q -f -- some arguments for you! : tests/userprog
-args-many:               -q -f -- a b c d e f g h i j k l m n o p q r s t u v : tests/userprog
-args-dbl-space:          -q -f -- two  spaces! : tests/userprog
-halt:                    -- -q : tests/userprog
-exit:                    -- -q : tests/userprog
-create-normal:           -- -q : tests/userprog
-create-empty:            -- -q : tests/userprog
-create-null:             -- -q : tests/userprog
-create-bad-ptr:          -- -q : tests/userprog
-create-long:             -- -q : tests/userprog
-create-exists:           -- -q : tests/userprog
-create-bound:            -- -q : tests/userprog
-open-normal:             -- -q : tests/userprog
-open-missing:            -- -q : tests/userprog
-open-boundary:           -- -q : tests/userprog
-open-empty:              -- -q : tests/userprog
-open-null:               -- -q : tests/userprog
-open-bad-ptr:            -- -q : tests/userprog
-open-twice:              -- -q : tests/userprog
-close-normal:            -- -q : tests/userprog
-close-twice:             -- -q : tests/userprog
-close-bad-fd:            -- -q : tests/userprog
-read-normal:             -- -q : tests/userprog
-read-bad-ptr:            -- -q : tests/userprog
-read-boundary:           -- -q : tests/userprog
-read-zero:               -- -q : tests/userprog
-read-stdout:             -- -q : tests/userprog
-read-bad-fd:             -- -q : tests/userprog
-write-normal:            -- -q : tests/userprog
-write-bad-ptr:           -- -q : tests/userprog
-write-boundary:          -- -q : tests/userprog
-write-zero:              -- -q : tests/userprog
-write-stdin:             -- -q : tests/userprog
-write-bad-fd:            -- -q : tests/userprog
-fork-once:               -- -q : tests/userprog
-fork-multiple:           -- -q : tests/userprog
-fork-recursive:          -- -q : tests/userprog
-fork-read:               -- -q : tests/userprog
-fork-close:              -- -q : tests/userprog
-fork-boundary:           -- -q : tests/userprog
-exec-once:               -- -q : tests/userprog
-exec-arg:                -- -q : tests/userprog
-exec-boundary:           -- -q : tests/userprog
-exec-missing:            -- -q : tests/userprog
-exec-bad-ptr:            -- -q : tests/userprog
-exec-read:               -- -q : tests/userprog
-wait-simple:             -- -q : tests/userprog
-wait-twice:              -- -q : tests/userprog
-wait-killed:             -- -q : tests/userprog
-wait-bad-pid:            -- -q : tests/userprog
-multi-recurse:           -- -q : tests/userprog
-multi-child-fd:          -- -q : tests/userprog
-rox-simple:              -- -q : tests/userprog
-rox-child:               -- -q : tests/userprog
-rox-multichild:          -- -q : tests/userprog
-bad-read:                -- -q : tests/userprog
-bad-write:               -- -q : tests/userprog
-bad-read2:               -- -q : tests/userprog
-bad-write2:              -- -q : tests/userprog
-bad-jump:                -- -q : tests/userprog
-bad-jump2:               -- -q : tests/userprog
+[userprog]
+args-none | --fs-disk=10 -p tests/userprog/args-none:args-none | -q   -f run | 'args-none' | tests/userprog
+args-single | --fs-disk=10 -p tests/userprog/args-single:args-single | -q   -f run | 'args-single onearg' | tests/userprog
+args-multiple | --fs-disk=10 -p tests/userprog/args-multiple:args-multiple | -q   -f run | 'args-multiple some arguments for you!' | tests/userprog
+args-many | --fs-disk=10 -p tests/userprog/args-many:args-many | -q   -f run | 'args-many a b c d e f g h i j k l m n o p q r s t u v' | tests/userprog
+args-dbl-space | --fs-disk=10 -p tests/userprog/args-dbl-space:args-dbl-space | -q   -f run | 'args-dbl-space two  spaces!' | tests/userprog
+halt | --fs-disk=10 -p tests/userprog/halt:halt | -q   -f run | 'halt' | tests/userprog
+exit | --fs-disk=10 -p tests/userprog/exit:exit | -q   -f run | 'exit' | tests/userprog
+create-normal | --fs-disk=10 -p tests/userprog/create-normal:create-normal | -q   -f run | 'create-normal' | tests/userprog
+create-empty | --fs-disk=10 -p tests/userprog/create-empty:create-empty | -q   -f run | 'create-empty' | tests/userprog
+create-null | --fs-disk=10 -p tests/userprog/create-null:create-null | -q   -f run | 'create-null' | tests/userprog
+create-bad-ptr | --fs-disk=10 -p tests/userprog/create-bad-ptr:create-bad-ptr | -q   -f run | 'create-bad-ptr' | tests/userprog
+create-long | --fs-disk=10 -p tests/userprog/create-long:create-long | -q   -f run | 'create-long' | tests/userprog
+create-exists | --fs-disk=10 -p tests/userprog/create-exists:create-exists | -q   -f run | 'create-exists' | tests/userprog
+create-bound | --fs-disk=10 -p tests/userprog/create-bound:create-bound | -q   -f run | 'create-bound' | tests/userprog
+open-normal | --fs-disk=10 -p tests/userprog/open-normal:open-normal -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'open-normal' | tests/userprog
+open-missing | --fs-disk=10 -p tests/userprog/open-missing:open-missing | -q   -f run | 'open-missing' | tests/userprog
+open-boundary | --fs-disk=10 -p tests/userprog/open-boundary:open-boundary -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'open-boundary' | tests/userprog
+open-empty | --fs-disk=10 -p tests/userprog/open-empty:open-empty | -q   -f run | 'open-empty' | tests/userprog
+open-null | --fs-disk=10 -p tests/userprog/open-null:open-null | -q   -f run | 'open-null' | tests/userprog
+open-bad-ptr | --fs-disk=10 -p tests/userprog/open-bad-ptr:open-bad-ptr | -q   -f run | 'open-bad-ptr' | tests/userprog
+open-twice | --fs-disk=10 -p tests/userprog/open-twice:open-twice -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'open-twice' | tests/userprog
+close-normal | --fs-disk=10 -p tests/userprog/close-normal:close-normal -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'close-normal' | tests/userprog
+close-twice | --fs-disk=10 -p tests/userprog/close-twice:close-twice -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'close-twice' | tests/userprog
+close-bad-fd | --fs-disk=10 -p tests/userprog/close-bad-fd:close-bad-fd | -q   -f run | 'close-bad-fd' | tests/userprog
+read-normal | --fs-disk=10 -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'read-normal' | tests/userprog
+read-bad-ptr | --fs-disk=10 -p tests/userprog/read-bad-ptr:read-bad-ptr -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'read-bad-ptr' | tests/userprog
+read-boundary | --fs-disk=10 -p tests/userprog/read-boundary:read-boundary -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'read-boundary' | tests/userprog
+read-zero | --fs-disk=10 -p tests/userprog/read-zero:read-zero -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'read-zero' | tests/userprog
+read-stdout | --fs-disk=10 -p tests/userprog/read-stdout:read-stdout | -q   -f run | 'read-stdout' | tests/userprog
+read-bad-fd | --fs-disk=10 -p tests/userprog/read-bad-fd:read-bad-fd | -q   -f run | 'read-bad-fd' | tests/userprog
+write-normal | --fs-disk=10 -p tests/userprog/write-normal:write-normal -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'write-normal' | tests/userprog
+write-bad-ptr | --fs-disk=10 -p tests/userprog/write-bad-ptr:write-bad-ptr -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'write-bad-ptr' | tests/userprog
+write-boundary | --fs-disk=10 -p tests/userprog/write-boundary:write-boundary -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'write-boundary' | tests/userprog
+write-zero | --fs-disk=10 -p tests/userprog/write-zero:write-zero -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'write-zero' | tests/userprog
+write-stdin | --fs-disk=10 -p tests/userprog/write-stdin:write-stdin | -q   -f run | 'write-stdin' | tests/userprog
+write-bad-fd | --fs-disk=10 -p tests/userprog/write-bad-fd:write-bad-fd | -q   -f run | 'write-bad-fd' | tests/userprog
+fork-once | --fs-disk=10 -p tests/userprog/fork-once:fork-once | -q   -f run | 'fork-once' | tests/userprog
+fork-multiple | --fs-disk=10 -p tests/userprog/fork-multiple:fork-multiple | -q   -f run | 'fork-multiple' | tests/userprog
+fork-recursive | --fs-disk=10 -p tests/userprog/fork-recursive:fork-recursive | -q   -f run | 'fork-recursive' | tests/userprog
+fork-read | --fs-disk=10 -p tests/userprog/fork-read:fork-read -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'fork-read' | tests/userprog
+fork-close | --fs-disk=10 -p tests/userprog/fork-close:fork-close -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'fork-close' | tests/userprog
+fork-boundary | --fs-disk=10 -p tests/userprog/fork-boundary:fork-boundary | -q   -f run | 'fork-boundary' | tests/userprog
+exec-once | --fs-disk=10 -p tests/userprog/exec-once:exec-once -p tests/userprog/child-simple:child-simple | -q   -f run | 'exec-once' | tests/userprog
+exec-arg | --fs-disk=10 -p tests/userprog/exec-arg:exec-arg -p tests/userprog/child-args:child-args | -q   -f run | 'exec-arg' | tests/userprog
+exec-boundary | --fs-disk=10 -p tests/userprog/exec-boundary:exec-boundary -p tests/userprog/child-simple:child-simple | -q   -f run | 'exec-boundary' | tests/userprog
+exec-missing | --fs-disk=10 -p tests/userprog/exec-missing:exec-missing | -q   -f run | 'exec-missing' | tests/userprog
+exec-bad-ptr | --fs-disk=10 -p tests/userprog/exec-bad-ptr:exec-bad-ptr | -q   -f run | 'exec-bad-ptr' | tests/userprog
+exec-read | --fs-disk=10 -p tests/userprog/exec-read:exec-read -p ../../tests/userprog/sample.txt:sample.txt -p tests/userprog/child-read:child-read | -q   -f run | 'exec-read' | tests/userprog
+wait-simple | --fs-disk=10 -p tests/userprog/wait-simple:wait-simple -p tests/userprog/child-simple:child-simple | -q   -f run | 'wait-simple' | tests/userprog
+wait-twice | --fs-disk=10 -p tests/userprog/wait-twice:wait-twice -p tests/userprog/child-simple:child-simple | -q   -f run | 'wait-twice' | tests/userprog
+wait-killed | --fs-disk=10 -p tests/userprog/wait-killed:wait-killed -p tests/userprog/child-bad:child-bad | -q   -f run | 'wait-killed' | tests/userprog
+wait-bad-pid | --fs-disk=10 -p tests/userprog/wait-bad-pid:wait-bad-pid | -q   -f run | 'wait-bad-pid' | tests/userprog
+multi-recurse | --fs-disk=10 -p tests/userprog/multi-recurse:multi-recurse | -q   -f run | 'multi-recurse 15' | tests/userprog
+multi-child-fd | --fs-disk=10 -p tests/userprog/multi-child-fd:multi-child-fd -p ../../tests/userprog/sample.txt:sample.txt -p tests/userprog/child-close:child-close | -q   -f run | 'multi-child-fd' | tests/userprog
+rox-simple | --fs-disk=10 -p tests/userprog/rox-simple:rox-simple | -q   -f run | 'rox-simple' | tests/userprog
+rox-child | --fs-disk=10 -p tests/userprog/rox-child:rox-child -p tests/userprog/child-rox:child-rox | -q   -f run | 'rox-child' | tests/userprog
+rox-multichild | --fs-disk=10 -p tests/userprog/rox-multichild:rox-multichild -p tests/userprog/child-rox:child-rox | -q   -f run | 'rox-multichild' | tests/userprog
+bad-read | --fs-disk=10 -p tests/userprog/bad-read:bad-read | -q   -f run | 'bad-read' | tests/userprog
+bad-write | --fs-disk=10 -p tests/userprog/bad-write:bad-write | -q   -f run | 'bad-write' | tests/userprog
+bad-read2 | --fs-disk=10 -p tests/userprog/bad-read2:bad-read2 | -q   -f run | 'bad-read2' | tests/userprog
+bad-write2 | --fs-disk=10 -p tests/userprog/bad-write2:bad-write2 | -q   -f run | 'bad-write2' | tests/userprog
+bad-jump | --fs-disk=10 -p tests/userprog/bad-jump:bad-jump | -q   -f run | 'bad-jump' | tests/userprog
+bad-jump2 | --fs-disk=10 -p tests/userprog/bad-jump2:bad-jump2 | -q   -f run | 'bad-jump2' | tests/userprog
 
-[Base]
-lg-create:               -- -q : tests/filesys/base
-lg-full:                 -- -q : tests/filesys/base
-lg-random:               -- -q : tests/filesys/base
-lg-seq-block:            -- -q : tests/filesys/base
-lg-seq-random:           -- -q : tests/filesys/base
-sm-create:               -- -q : tests/filesys/base
-sm-full:                 -- -q : tests/filesys/base
-sm-random:               -- -q : tests/filesys/base
-sm-seq-block:            -- -q : tests/filesys/base
-sm-seq-random:           -- -q : tests/filesys/base
-syn-remove:              -- -q : tests/filesys/base
-syn-write:               -- -q : tests/filesys/base
+[filesys/base]
+lg-create | --fs-disk=10 -p tests/filesys/base/lg-create:lg-create | -q   -f run | 'lg-create' | tests/filesys/base
+lg-full | --fs-disk=10 -p tests/filesys/base/lg-full:lg-full | -q   -f run | 'lg-full' | tests/filesys/base
+lg-random | --fs-disk=10 -p tests/filesys/base/lg-random:lg-random | -q   -f run | 'lg-random' | tests/filesys/base
+lg-seq-block | --fs-disk=10 -p tests/filesys/base/lg-seq-block:lg-seq-block | -q   -f run | 'lg-seq-block' | tests/filesys/base
+lg-seq-random | --fs-disk=10 -p tests/filesys/base/lg-seq-random:lg-seq-random | -q   -f run | 'lg-seq-random' | tests/filesys/base
+sm-create | --fs-disk=10 -p tests/filesys/base/sm-create:sm-create | -q   -f run | 'sm-create' | tests/filesys/base
+sm-full | --fs-disk=10 -p tests/filesys/base/sm-full:sm-full | -q   -f run | 'sm-full' | tests/filesys/base
+sm-random | --fs-disk=10 -p tests/filesys/base/sm-random:sm-random | -q   -f run | 'sm-random' | tests/filesys/base
+sm-seq-block | --fs-disk=10 -p tests/filesys/base/sm-seq-block:sm-seq-block | -q   -f run | 'sm-seq-block' | tests/filesys/base
+sm-seq-random | --fs-disk=10 -p tests/filesys/base/sm-seq-random:sm-seq-random | -q   -f run | 'sm-seq-random' | tests/filesys/base
+syn-read | --fs-disk=10 -p tests/filesys/base/syn-read:syn-read -p tests/filesys/base/child-syn-read:child-syn-read | -q   -f run | 'syn-read' | tests/filesys/base
+syn-remove | --fs-disk=10 -p tests/filesys/base/syn-remove:syn-remove | -q   -f run | 'syn-remove' | tests/filesys/base
+syn-write | --fs-disk=10 -p tests/filesys/base/syn-write:syn-write -p tests/filesys/base/child-syn-wrt:child-syn-wrt | -q   -f run | 'syn-write' | tests/filesys/base
 
-[No VM]
-multi-oom:               -- -q : tests/userprog/no-vm
+[userprog/no-vm]
+multi-oom | --fs-disk=10 -p tests/userprog/no-vm/multi-oom:multi-oom | -q   -f run | 'multi-oom' | tests/userprog/no-vm
 
-[Thread]
-alarm-single:            -- -q : tests/threads
-alarm-multiple:          -- -q : tests/threads
-alarm-simultaneous:      -- -q : tests/threads
-alarm-priority:          -- -q : tests/threads
-alarm-zero:              -- -q : tests/threads
-alarm-negative:          -- -q : tests/threads
-priority-change:         -- -q : tests/threads
-priority-donate-one:     -- -q : tests/threads
-priority-donate-multiple: -- -q : tests/threads
-priority-donate-multiple2:  -- -q : tests/threads
-priority-donate-nest:    -- -q : tests/threads
-priority-donate-sema:    -- -q : tests/threads
-priority-donate-lower:   -- -q : tests/threads
-priority-fifo:           -- -q : tests/threads
-priority-preempt:        -- -q : tests/threads
-priority-sema:           -- -q : tests/threads
-priority-condvar:        -- -q : tests/threads
-priority-donate-chain:   -- -q : tests/threads
+[threads]
+alarm-single | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-single' | tests/threads
+alarm-multiple | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-multiple' | tests/threads
+alarm-simultaneous | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-simultaneous' | tests/threads
+alarm-priority | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-priority' | tests/threads
+alarm-zero | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-zero' | tests/threads
+alarm-negative | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-negative' | tests/threads
+priority-change | --fs-disk=10 | -q  -threads-tests -f run | 'priority-change' | tests/threads
+priority-donate-one | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-one' | tests/threads
+priority-donate-multiple | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-multiple' | tests/threads
+priority-donate-multiple2 | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-multiple2' | tests/threads
+priority-donate-nest | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-nest' | tests/threads
+priority-donate-sema | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-sema' | tests/threads
+priority-donate-lower | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-lower' | tests/threads
+priority-fifo | --fs-disk=10 | -q  -threads-tests -f run | 'priority-fifo' | tests/threads
+priority-preempt | --fs-disk=10 | -q  -threads-tests -f run | 'priority-preempt' | tests/threads
+priority-sema | --fs-disk=10 | -q  -threads-tests -f run | 'priority-sema' | tests/threads
+priority-condvar | --fs-disk=10 | -q  -threads-tests -f run | 'priority-condvar' | tests/threads
+priority-donate-chain | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-chain' | tests/threads
 
-[Extra]
-dup2-complex:            -- -q : tests/userprog
-dup2-simple:             -- -q : tests/userprog
+[extra]
+dup2-simple  | --fs-disk=10 -p tests/userprog/dup2/dup2-simple:dup2-simple   | -q -f run | 'dup2-simple'   | tests/userprog/dup2
+dup2-complex | --fs-disk=10 -p tests/userprog/dup2/dup2-complex:dup2-complex | -q -f run | 'dup2-complex' | tests/userprog/dup2
 
-# (마지막 공백을 남겨두세요)
+
+# Total testcases: 97
+# Generated on 2025-07-20

--- a/pintos/userprog/select_test.sh
+++ b/pintos/userprog/select_test.sh
@@ -35,8 +35,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../activate"
 
 # --------------------------------------------------
-# .test_config 읽어서 tests 배열과 config_map 생성
-# 형식: 테스트이름: 실행인자 (’--' 포함)
+# .test_config 읽어서 5-필드로 파싱
+# 형식: 테스트명 | Pre-Args | Post-Args | Prog-Args | Test-Path
 # --------------------------------------------------
 CONFIG_FILE="${SCRIPT_DIR}/.test_config"
 if [[ ! -f "$CONFIG_FILE" ]]; then
@@ -44,14 +44,14 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
   exit 1
 fi
 
-declare -A config_args   # 실행 인자
-declare -A config_result # 결과 파일 경로
+declare -A config_pre_args    
+declare -A config_post_args   
+declare -A config_prog_args   
+declare -A config_result      
 declare -A GROUP_TESTS TEST_GROUP MENU_TESTS
 declare -a ORDERED_GROUPS
 tests=()
 
-# --- 섹션과 테스트 라인 함께 파싱 ---
-declare -a ORDERED_GROUPS
 current_group=""
 
 while IFS= read -r raw; do
@@ -66,14 +66,18 @@ while IFS= read -r raw; do
     ORDERED_GROUPS+=("$current_group")
     GROUP_TESTS["$current_group"]=""
   else
-    # test: args : result_dir
-    IFS=':' read -r test args result_dir <<< "$line"
-    test="$(echo "$test"       | xargs)"
-    args="$(echo "$args"       | xargs)"
-    result_dir="$(echo "$result_dir" | xargs)"
+    # 5-필드 파싱: test | pre_args | post_args | prog_args | test_path
+    IFS='|' read -r test pre_args post_args prog_args test_path <<< "$line"
+    test="$(echo "$test"         | xargs)"
+    pre_args="$(echo "$pre_args"   | xargs)"
+    post_args="$(echo "$post_args" | xargs)"
+    prog_args="$(echo "$prog_args" | xargs)"   # 따옴표 포함된 상태 유지
+    test_path="$(echo "$test_path" | xargs)"
 
-    config_args["$test"]="$args"
-    config_result["$test"]="$result_dir"
+    config_pre_args["$test"]="$pre_args"
+    config_post_args["$test"]="$post_args"
+    config_prog_args["$test"]="$prog_args"
+    config_result["$test"]="$test_path"
     tests+=("$test")
 
     # 그룹에 추가
@@ -173,28 +177,24 @@ failed=()
   total=${#sel_tests[@]}
   for test in "${sel_tests[@]}"; do
     echo
-    # config에서 전체 args 가져오기
-    args_full="${config_args[$test]}"      # ex: "-mlfqs -- -q" 또는 "-- -q"
-    
-    # “--” 앞뒤로 나누기
-    kernel_args="$(echo "${args_full%%--*}" | xargs)"   # ex: "-mlfqs" 또는 ""
-    run_args="$(echo "${args_full##*--}" | xargs)"   # ex: "-q"
+    # 5-필드 포맷에서 각 args 가져오기
+    pre_args="${config_pre_args[$test]}"    # -- 이전 인자들
+    post_args="${config_post_args[$test]}"  # -- 이후 run 이전 인자들
+    prog_args="${config_prog_args[$test]}"  # '…' 로 묶인 프로그램 + 인자 전체
     dir="${config_result[$test]}"
     res="${dir}/${test}.result"
-    # ck= "${dir}/${test}.ck"
 
     mkdir -p ${dir}
     
     if [[ "$MODE" == "-q" ]]; then
       # 배치 모드
-      cmd="pintos ${kernel_args:+${kernel_args}} -- ${run_args} run ${test}"
-      make_cmd="make -s ${res} ARGS=\"${kernel_args:+${kernel_args}} -- ${run_args}\""
+      cmd="pintos ${pre_args} -- ${post_args} '${prog_args}'"
       echo "Running ${test} in batch mode... "
       echo "\$ ${cmd}  # in batch mode"
       echo
       # batch 모드: ARGS 전달
       if make -s ${res} \
-            ARGS="${kernel_args:+${kernel_args}} -- ${run_args}"; then
+            ARGS="${pre_args} -- ${post_args} '${prog_args}'"; then
         # make가 성공했으면 .result 안에 PASS 키워드 검사
         if grep -q '^PASS' ${res}; then
           echo "PASS"; passed+=("$test")
@@ -207,14 +207,13 @@ failed=()
 fi
     else
       # interactive debug 모드: QEMU 포그라운드 실행 + tee 로 .output 캡처 후 .result 생성
-      cmd="pintos -v -k -m 20 --gdb --fs-disk=10 -p ${dir}/${test}:${test} -- ${kernel_args:+${kernel_args}} run '${test}${run_args:+ ${run_args}}'"
-      echo "사용할 커맨드 : ${cmd}"
       echo -e "=== Debugging \e[33m${test}\e[0m ($(( count + 1 ))/${total}) ==="
       echo -e "\e[33mVSCode의 \"Pintos Debug\" 디버그를 시작하세요.\e[0m"
       echo " * QEMU 창이 뜨고, gdb stub은 localhost:1234 에서 대기합니다."
       echo " * 내부 출력은 터미널에 보이면서 '${dir}/${test}.output'에도 저장됩니다."
       echo
 
+      cmd="pintos --gdb ${pre_args} -- ${post_args} '${prog_args}'"
       echo "\$ ${cmd}"
       eval "${cmd}" 2>&1 | tee "${dir}/${test}.output"
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -41,6 +41,60 @@ syscall_init (void) {
 void
 syscall_handler (struct intr_frame *f UNUSED) {
 	// TODO: Your implementation goes here.
-	printf ("system call!\n");
+	switch (f->R.rax)
+	{
+		case SYS_HALT:
+			break;
+		case SYS_EXIT:
+			exit (f->R.rdi);
+			break;
+		case SYS_FORK:
+			break;
+		case SYS_EXEC:
+			break;
+		case SYS_WAIT:
+			break;
+		case SYS_CREATE:
+			break;
+		case SYS_REMOVE:
+			break;
+		case SYS_OPEN:
+			break;
+		case SYS_FILESIZE:
+			break;
+		case SYS_READ:
+			break;
+		case SYS_WRITE:
+			f->R.rax = write (f->R.rdi, f->R.rsi, f->R.rdx);
+			break;
+		case SYS_SEEK:
+			break;
+		case SYS_TELL:
+			break;
+		case SYS_CLOSE:
+			break;
+		default:
+			printf ("system call!\n");
+			thread_exit ();
+			break;
+	}
+
+}
+
+void
+exit (int status) {
+	printf("%s: exit(%d)\n", thread_name (), status);
 	thread_exit ();
+}
+
+int
+write (int fd, const void *buffer, unsigned length) {
+	// 포인터 체크 함수 복붙
+	if (fd == 1) {
+		putbuf (buffer, length);
+		return length;
+	}
+	else {
+		// fd 구현 후에 가능할듯
+	}
 }


### PR DESCRIPTION
# 테스트 쉘 파일 수정
- 기존의 테스트 쉘 파일은 단순 테스트를 위한 argument passing 테스트만 가능하게 수정하였는데, 나머지 테스트케이스도 정상적으로 가능하게 변경하였습니다.
# exit 시스템콜 구현
- 기본적인 exit 시스템콜을 구현하였습니다.
- 나중에 fork 기능을 구현하면서 자식 프로세스의 exit 을 알 수 있게 수정해야 할 거 같습니다
# write 시스템콜 부분 구현
- 아주 간단한 write로, putbuf로 출력이 가능하게 구현하였습니다.
- 해당 함수를 먼저 push 해서, 출력확인을 위해 기본적인 stdout을 가능하게 만들었습니다.