### PR TITLE
System Call: syscall_handler 에서 halt 호출

### DIFF
--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -53,6 +53,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	switch (f->R.rax)
 	{
 		case SYS_HALT:
+			halt();
 			break;
 		case SYS_EXIT:
 			exit (f->R.rdi);
@@ -83,7 +84,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_CLOSE:
 			break;
 		default:
-			printf ("system call!\n");
+			printf ("system call exiting\n");
 			thread_exit ();
 			break;
 	}
@@ -94,6 +95,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	유저 프로그램에서 OS를 멈출 수 있는 유일한 시스템 콜 이다. */
 void halt (void) {
 	power_off(); 
+}
 
 /* exit로 호출한 스레드를 종료하는 함수 */
 void


### PR DESCRIPTION
syscall_handler함수 안에서
`case SYS_HALT: `부분에 halt 함수 호출이 빠진 부분을 수정했습니다.

+ halt 함수에 있던 오타를 수정 했습니다: } 가 빠짐 