### PR TITLE
UPDATE : 파일 디스크럽터 선언 위치 프로세스로 이동 및 fd_node 생성

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,7 +5,6 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
-#include "userprog/process.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -100,7 +99,7 @@ struct thread {
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */
-	struct fd_table *fd;
+	struct fd_table *fd_table;
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "userprog/process.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -27,16 +28,6 @@ typedef int tid_t;
 #define PRI_MIN 0                       /* Lowest priority. */
 #define PRI_DEFAULT 31                  /* Default priority. */
 #define PRI_MAX 63                      /* Highest priority. */
-
-/* 파일 디스크립터 관련 */
-#define FDCOUNT_LIMIT 128
-
-/* 파일 디스크립터 테이블 구조체 */
-struct fd_table {
-	struct File *fd_address[64];
-	int fd_next;
-	int fd_limit;
-};
 
 /* A kernel thread or user process.
  *

--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -3,6 +3,25 @@
 
 #include "threads/thread.h"
 
+/* 파일 디스크립터 관련 */
+#define FDCOUNT_LIMIT 63
+
+/* 파일 디스크립터의 타입을 저장하기 위한 enum */
+enum fd_type { FD_NONE, FD_STDIN, FD_STDOUT, FD_FILE };
+
+/* 파일 디스크립터의 단위가 되는 구조체 */
+struct fd_node {
+	enum fd_type type;
+	struct file *file;
+};
+
+/* 프로세스마다 파일 디스크립터를 관리하기 위한 구조체 */
+struct fd_table {
+	struct fd_node *fd_node[64];
+	int fd_next;
+	int fd_limit;
+};
+
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_);
 int process_exec (void *f_name);

--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -4,6 +4,7 @@
 #include "threads/thread.h"
 
 /* 파일 디스크립터 관련 */
+#define FDCOUNT_START 2
 #define FDCOUNT_LIMIT 63
 
 /* 파일 디스크립터의 타입을 저장하기 위한 enum */
@@ -17,7 +18,7 @@ struct fd_node {
 
 /* 프로세스마다 파일 디스크립터를 관리하기 위한 구조체 */
 struct fd_table {
-	struct fd_node *fd_node[64];
+	struct fd_node fd_node[64];
 	int fd_next;
 	int fd_limit;
 };

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -233,12 +233,6 @@ thread_create (const char *name, int priority,
 	t->tf.cs = SEL_KCSEG;
 	t->tf.eflags = FLAG_IF;
 
-	t->fd = palloc_get_page (PAL_ZERO);
-	t->fd->fd_next = 2;
-	t->fd->fd_limit = FDCOUNT_LIMIT;
-	t->fd->fd_address[0] = STDIN_FILENO;
-	t->fd->fd_address[1] = STDOUT_FILENO;
-
 	/* Add to run queue. */
 	thread_unblock (t);
 	thread_maybe_yield();	// 나보다 우선순위가 큰 스레드가 생성될 수 있으니까 체크

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -33,6 +33,12 @@ initd 및 기타 프로세스를 위한 일반 프로세스 초기화 함수입�
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
+
+	current->fd = palloc_get_page (PAL_ZERO);
+	current->fd->fd_next = 2;
+	current->fd->fd_limit = FDCOUNT_LIMIT;
+	current->fd->fd_node[0]->type = FD_STDIN;
+	current->fd->fd_node[1]->type = FD_STDOUT;
 }
 
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -34,11 +34,11 @@ static void
 process_init (void) {
 	struct thread *current = thread_current ();
 
-	current->fd = palloc_get_page (PAL_ZERO);
-	current->fd->fd_next = 2;
-	current->fd->fd_limit = FDCOUNT_LIMIT;
-	current->fd->fd_node[0]->type = FD_STDIN;
-	current->fd->fd_node[1]->type = FD_STDOUT;
+	current->fd_table = palloc_get_page (PAL_ZERO);
+	current->fd_table->fd_next = FDCOUNT_START;
+	current->fd_table->fd_limit = FDCOUNT_LIMIT;
+	current->fd_table->fd_node[0].type = FD_STDIN;
+	current->fd_table->fd_node[1].type = FD_STDOUT;
 }
 
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -7,6 +7,8 @@
 #include "userprog/gdt.h"
 #include "threads/flags.h"
 #include "intrinsic.h"
+#include "filesys/file.h"
+#include "filesys/filesys.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -111,13 +113,18 @@ sys_exit (int status) {
 int
 sys_write (int fd, const void *buffer, unsigned length) {
 	check_address (buffer);
-	if (fd == 1) {
+	struct thread *current = thread_current ();
+
+	if (current->fd->fd_node[fd]->type == FD_STDOUT) {
 		putbuf (buffer, length);
 		return length;
 	}
+	else if (current->fd->fd_node[fd]->type == FD_FILE) {
+		return file_write (current->fd->fd_node[fd]->file, buffer, length);
+	}
 	else {
-		// write 스켈레톤
-		return file_write (thread_current ()->fd->fd_address[fd], buffer, length);
+		// file도 아닌 경우는 뭘 반환해야지?
+		sys_exit (-1);
 	}
 }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -9,6 +9,7 @@
 #include "intrinsic.h"
 #include "filesys/file.h"
 #include "filesys/filesys.h"
+#include "userprog/process.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -115,12 +116,12 @@ sys_write (int fd, const void *buffer, unsigned length) {
 	check_address (buffer);
 	struct thread *current = thread_current ();
 
-	if (current->fd->fd_node[fd]->type == FD_STDOUT) {
+	if (current->fd_table->fd_node[fd].type == FD_STDOUT) {
 		putbuf (buffer, length);
 		return length;
 	}
-	else if (current->fd->fd_node[fd]->type == FD_FILE) {
-		return file_write (current->fd->fd_node[fd]->file, buffer, length);
+	else if (current->fd_table->fd_node[fd].type == FD_FILE) {
+		return file_write (current->fd_table->fd_node[fd].file, buffer, length);
 	}
 	else {
 		// file도 아닌 경우는 뭘 반환해야지?


### PR DESCRIPTION
# 파일 디스크럽터 선언 위치 프로세스로 이동 및 fd_node 생성
- 파일 디스크립터는 개념적으로는 스레드에 있는 느낌보단 프로세스에 있는게 맞는거 같습니다.
- 때문에 선언 자체는 프로세스 파일에 옮기고 초기화도 process_init 함수에 초기화를 진행하였습니다.
- 나중에 fork 기능을 만들 경우, duplicate 해야 할 수도 있습니다.
# fd_node 구조체 추가
- File 포인터를 받는것이 아닌, fd_node 구조체를 추가하였습니다.
- 이는 추가로 해당 fd의 타입을 저장하기 위한 enum fd_type 이 존재합니다.
- 이를 통해 해당 enum fd_type 을 통해, 해당 fd가 어떤 타입인지 체크할 수 있으며, 시스템콜 부분에서도 전달받은 fd이 enum fd_type 를 확인하고 적절하게 대응하도록 수정하였습니다.