### PR TITLE
system call sys_open 함수 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -100,6 +100,9 @@ struct thread {
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */
 	struct fd_table *fd_table;
+	
+	// 실행 중인 파일에 대한 포인터
+	struct file *running_file;
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -39,6 +39,7 @@ process_init (void) {
 	current->fd_table->fd_limit = FDCOUNT_LIMIT;
 	current->fd_table->fd_node[0].type = FD_STDIN;
 	current->fd_table->fd_node[1].type = FD_STDOUT;
+
 }
 
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.
@@ -203,6 +204,16 @@ int
 process_exec (void *f_name) {
 	char *file_name = f_name;
 	bool success;
+
+	//실행 중인 파일 오픈
+	struct file *file = filesys_open(f_name);
+	if (file == NULL){
+		return -1;
+	}
+
+	//실행 중인 파일 저장
+	thread_current()->running_file = file;
+	file_deny_write(file);
 
 	/* We cannot use the intr_frame in the thread structure.
 	 * This is because when current thread rescheduled,

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -68,12 +68,12 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_WAIT:
 			break;
 		case SYS_CREATE:
-			sys_create (f-> R.rdi, f -> R.rsi);
+			f->R.rax = sys_create (f-> R.rdi, f -> R.rsi);
 			break;
 		case SYS_REMOVE:
 			break;
 		case SYS_OPEN:
-			sys_open(f->R.rdi);
+			f->R.rax = sys_open(f->R.rdi);
 			break;
 		case SYS_FILESIZE:
 			break;
@@ -140,34 +140,13 @@ sys_create (const char *file, unsigned initial_size) {
 
 
 int
-sys_open(const char *name){
-	//1. filename이 NULL이거나 사용자 메모리 범위(0x8048000 ~ 0xC0000000) 밖인지 확인 - 유효하지 않으면 exit(-1)
-	//예외 처리
-	check_address(name);
+sys_open (const char *name){
+	
+	check_address (name);
 
-    //2. filename이 빈 문자열("")인지 확인 - 빈 문자열이면 return -1
-	if (name[0] == '\0'){
-		return -1;
-	}
-
-    //3. filesys_open(filename)으로 파일 열기 - 실패 시 return -1
-	struct file *file = filesys_open(name);
-	if (file == NULL) {
-    	return -1;
-	}
-
-   	//4. running_file과 동일하면 file_deny_write 호출
-	//포인터 값이 아니라 inode로 비교하는 이유는
-	//filesys_open() 같은 함수는 같은 파일을 여러 번 열면 다른 file 포인터를 줘도 같은 inode를 공유
-	if (thread_current()->running_file != NULL &&
-    file_get_inode(thread_current()->running_file) == file_get_inode(file)) {
-    file_deny_write(file);
-	}
-
-
-    //5. fd_table->fd_next에서 fd 할당 (2 <= fd < 63) - 없으면 file_close 후 return -1
     int fd = -1;
-	for (int i = thread_current()->fd_table->fd_next; i < FDCOUNT_LIMIT; i++){
+
+	for (int i = 0; i < FDCOUNT_LIMIT; i++){
 		if (thread_current()->fd_table->fd_node[i].type == FD_NONE){
 			fd = i;
 			break;
@@ -175,18 +154,20 @@ sys_open(const char *name){
 	}
 
 	if (fd == -1){
-		file_close(file);
 		return -1;
 	}
+	else{
 
-	//6. fd_node[fd].type = FD_FILE, fd_node[fd].file = file
-	thread_current()->fd_table->fd_node[fd].type = FD_FILE;
-	thread_current()->fd_table->fd_node[fd].file = file;
-	
-	//7. fd_table->fd_next 증가
-    thread_current()->fd_table->fd_next = fd + 1;
-	
-	//8. return fd
+		struct file *file = filesys_open(name);
+		if (file == NULL) {
+    		return -1;
+		}
+
+		thread_current()->fd_table->fd_node[fd].type = FD_FILE;
+		thread_current()->fd_table->fd_node[fd].file = file;
+
+	}
+
 	return fd;
 
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -146,10 +146,9 @@ sys_open(const char *name){
 	//1. 테이블을 순회하여 사용 가능한 빈 항목을 찾음
 
 	//2. filesys_open 호출
-	struct file *file = filesys_open(name);
+	//struct file *file = filesys_open(name);
 	
-	//예외 처리
-	check_address(file);
+	
 
 	//3. 파일 디스크립터 테이블 빈 곳에 저장
 
@@ -157,5 +156,27 @@ sys_open(const char *name){
 
 	//5. fd struct 생성 및 fd table에 삽입 -> ?
 	//새로 만들었으니까 만들어주라는 건가(?)
+
+	//1. filename이 NULL이거나 사용자 메모리 범위(0x8048000 ~ 0xC0000000) 밖인지 확인 - 유효하지 않으면 exit(-1)
+	//예외 처리
+	check_address(name);
+
+    //2. filename이 빈 문자열("")인지 확인 - 빈 문자열이면 return -1
+	if (name[0] == '\0'){
+		return -1;
+	}
+
+    //3. filesys_open(filename)으로 파일 열기 - 실패 시 return -1
+	struct file *file = filesys_open(name);
+	if (file == NULL) {
+    	return -1;
+	}
+
+   	//4. running_file과 동일하면 file_deny_write 호출
+	
+    //5. fd_table->fd_next에서 fd 할당 (2 <= fd < 63) - 없으면 file_close 후 return -1
+    //6. fd_node[fd].type = FD_FILE, fd_node[fd].file = file
+    //7. fd_table->fd_next 증가
+    //8. return fd
 
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -127,3 +127,27 @@ sys_create (const char *file, unsigned initial_size) {
 	check_address (file);
 	return filesys_create (file, initial_size);
 }
+
+
+
+int
+sys_open(const char *name){
+
+	//열린 파일을 디스크립터 테이블과 파일 테이블에 등록해야 함
+
+	//1. 테이블을 순회하여 사용 가능한 빈 항목을 찾음
+
+	//2. filesys_open 호출
+	struct file *file = filesys_open(name);
+	
+	//예외 처리
+	check_address(file);
+
+	//3. 파일 디스크립터 테이블 빈 곳에 저장
+
+	//4. 사용 가능한 파일 디스크립터를 찾음
+
+	//5. fd struct 생성 및 fd table에 삽입 -> ?
+	//새로 만들었으니까 만들어주라는 건가(?)
+
+}


### PR DESCRIPTION
**테스트 케이스 15번부터 21번 open 관련해서 전부 실패로 나옵니다.**

- `thread` 구조체에 `running_file` 필드를 추가하여 현재 실행 중인 파일 객체를 저장할 수 있도록 했습니다.
- 이 값은 `process_exec()` 함수 안에서 설정되며, 이후 `sys_open()` 시스템 콜에서 사용됩니다.

- `sys_open()` 시스템 콜은 파일 이름 유효성 검사를 먼저 수행한 뒤,
  - 파일 열기에 성공하면,
  - 실행 중인 파일(`running_file`)과 같은 inode인지 확인하고,
    - 동일한 파일이라면 `file_deny_write()`를 호출하여 쓰기를 방지합니다.

- 이후, `fd_table` 내 사용 가능한 파일 디스크립터 번호를 찾아 `file` 객체를 등록하고,
  - 해당 fd를 반환합니다.
  - 사용 가능한 fd가 없을 경우, `file_close()`를 호출하고 `-1`을 반환합니다.

- `file_get_inode()`를 이용해 파일 비교를 하는 이유는, 
   - filesys_open()을 여러 번 호출하면 서로 다른 file 포인터가 생성되더라도 
    - 같은 inode를 가리킬 수 있기 때문에, 파일 객체의 포인터가 아닌 inode를 기준으로 같은 파일인지 비교했습니다.


Q. 1번 예외 처리가 논리적으로 말이 되나요?
```
//1. filename이 NULL이거나 사용자 메모리 범위(0x8048000 ~ 0xC0000000) 밖인지 확인 - 유효하지 않으면 exit(-1)
	//예외 처리
	check_address(name);
```
이런 식으로 예외 처리를 작성했는데 주석이랑 목적이 안 맞고 논리적으로도 좀 이상한 것 같습니다.

Q. 1번과 2번 예외 처리가 사실상 같은 거 아닌가요?
```
    //2. filename이 빈 문자열("")인지 확인 - 빈 문자열이면 return -1
	if (name[0] == '\0'){
		return -1;
	}
```

name이 null인 거랑 name[0] == '\0' 이거랑 같은 거 아닌가 싶어서
예외처리가 이상하다 생각합니다. (제가 적었지만....)

내일 아침에 일어나서 디버거 하고 또 수정해 보겠습니다!