### PR TITLE
add : 시스템 콜 통일 및 정리

### DIFF
--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -2,27 +2,27 @@
 #define USERPROG_PROCESS_H
 
 #include "threads/thread.h"
-
-/* 파일 디스크립터 관련 */
-#define FDCOUNT_START 2
-#define FDCOUNT_LIMIT 63
+#include <hash.h>
 
 /* 파일 디스크립터의 타입을 저장하기 위한 enum */
 enum fd_type { FD_NONE, FD_STDIN, FD_STDOUT, FD_FILE };
 
 /* 파일 디스크립터의 단위가 되는 구조체 */
-struct fd_node {
+struct fd_value {
 	enum fd_type type;
 	struct file *file;
 };
 
 /* 프로세스마다 파일 디스크립터를 관리하기 위한 구조체 */
 struct fd_table {
-	struct fd_node fd_node[64];
-	int fd_next;
-	int fd_limit;
+	struct fd_value fd_node[64];
 };
 
+int process_file_open (const char *file_name);
+int process_file_length (int fd);
+int process_file_read (int fd, const void *buffer, unsigned size);
+int process_file_write (int fd, const void *buffer, unsigned size);
+void process_file_close (int fd);
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_);
 int process_exec (void *f_name);

--- a/pintos/include/userprog/syscall.h
+++ b/pintos/include/userprog/syscall.h
@@ -7,7 +7,11 @@ void syscall_init (void);
 
 void sys_halt (void);
 void sys_exit (int status);
-int sys_write (int fd, const void *buffer, unsigned length);
 bool sys_create (const char *file, unsigned initial_size);
+int sys_open (const char *file);
+int sys_filesize (int fd);
+int sys_read (int fd, const void *buffer, unsigned size);
+int sys_write (int fd, const void *buffer, unsigned size);
+void sys_close(int fd);
 
 #endif /* userprog/syscall.h */


### PR DESCRIPTION
# 시스템 콜 통일 및 정리
- 구현했던 기본적인 시스템콜을 정리하고, 개념에 따라 프로세스가 해야하는 일인 경우에는 해당 함수를 프로세스 파일에서 선언하였습니다.
# 파일 디스크립터 수정
- 기존 파일 디스크립터는 배열을 사용하고 있었는데, 의미없는 int next와 limit 변수가 있어서 제거하였습니다.
- 하지만 후에는 링크리스트나 해쉬 테이블로 변경해야할 것 같습니다.