### PR TITLE
System Call: wait 함수 

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -93,6 +93,16 @@ struct thread {
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
 
+	/* process_ wait */
+	struct semaphore wait_sema;
+	struct semaphore exit_sema;
+	struct list child_list;      /* fork()로 만든 자식들을 모아두는 리스트 */
+	struct list_elem child_elem; /* child_list에 끼울 리스트 엘렘 */
+	struct thread *parent;   
+	
+	bool wait_called;
+	int exit_status;
+
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -505,6 +505,15 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
+
+	/* process_wait*/
+	t -> wait_called = false;
+	t -> exit_status = -1;
+	
+	/* 세마포어 초기화를 해줘야 함 -> 안해주면 sema_down에서 영원히 락이 걸릴수 있음*/
+	sema_init(&t->wait_sema, 0);
+	sema_init(&t->exit_sema, 0);
+
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -148,7 +148,7 @@ sys_close (int fd){
 	process_file_close (fd);
 }
 
-void 
+int 
 sys_wait(tid_t pid) {
 	process_wait(pid);
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -66,6 +66,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_EXEC:
 			break;
 		case SYS_WAIT:
+			f->R.rax = sys_wait (f-> R.rdi);
 			break;
 		case SYS_CREATE:
 			f->R.rax = sys_create (f-> R.rdi, f -> R.rsi);
@@ -145,4 +146,9 @@ sys_write (int fd, const void *buffer, unsigned size) {
 void 
 sys_close (int fd){
 	process_file_close (fd);
+}
+
+void 
+sys_wait(tid_t pid) {
+	process_wait(pid);
 }


### PR DESCRIPTION
**syscall**안에서는 `process_wait`을 부르게 만들었고, **thread.c**안의 `process_wait`함수를 변경했습니다.

`process_wait`의 로직은
pid를 인자로 받아 현재 자식의 조건을 체크합니다.
이후에, 세마포어를 이용해 락을 걸고 `list_remove()`를 실행한 후 락을 풀어줍니다.
마지막에는 `exit_status`를 반환합니다. 


